### PR TITLE
Set no retention in DWHM db create query template

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ App can be run multiple times with the same config and the result is always the 
 Master users needs to be able to create users, schemas and roles.  
 
 ```
-CREATE DATABASE "DWHM_MYDATAWAREHOUSE";
+CREATE DATABASE "DWHM_MYDATAWAREHOUSE" DATA_RETENTION_TIME_IN_DAYS = 0;
 
 CREATE ROLE "DWHM_MYDATAWAREHOUSE";
 


### PR DESCRIPTION
Fixes #24 

Že to funguje jsem otestoval takto:
```
CREATE DATABASE "DWHM_TEST1" DATA_RETENTION_TIME_IN_DAYS = 0;
USE DATABASE "DWHM_TEST1";
CREATE SCHEMA DWHM_TEST ;
USE SCHEMA DWHM_TEST;
CREATE TABLE test (id int);
SHOW TABLES;
DROP DATABASE "DWHM_TEST1";
```

Případně můžeme na produkci nastavit ty existující pokud nejsou, ale radši jsem to zatím nepouštěl, netuším jestli to někde není jinak schválně. 

```
SHOW DATABASES LIKE 'DWHM_%';
// foreach
GRANT ROLE DWHM_WHATEVER TO ROLE ACCOUNTADMIN;
ALTER DATABASE DWHM_WHATEVER SET DATA_RETENTION_TIME_IN_DAYS = 0;
REVOKE ROLE DWHM_WHATEVER FROM ROLE ACCOUNTADMIN;
```