### PR TITLE
Set data retention to maximum of 7 days

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - docker build -t $APP_IMAGE --build-arg AWS_SECRET_ACCESS_KEY --build-arg AWS_ACCESS_KEY_ID .
   - >-
     travis_wait
-    60
+    120
     docker
     run
     -e HOST


### PR DESCRIPTION
Fixes #24 

Nastavuje 7 dní retention, pokud už není nižší (tj. nezvýší to 0 na devu). Bude fungovat, dokud někdo nebude chtít víc. Nově založené mají 7 days by default. Takže jakmile všechny produkční proběhnou aspoň jednou, tak se to může zas odstranit nebo disablovat. Případně bysme tam mohli vyjmenovat explicitně ty, co mají víc, ale to asi není úplně čisté. 

Zkoušel jsem i nastavit nové DB na "transient" (tj. bez fail-safe, jen s time-travel). Jenže transient věci [mají omezený time-travel jen na 1 den](https://docs.snowflake.net/manuals/user-guide/tables-temp-transient.html#comparison-of-table-types) :( 

## Testování:

Spustil jsem 

```
SET dwhm_db = '"DWHM_TRAVIS_TESTS"';
SELECT $dwhm_db, $current_role;
GRANT ROLE IDENTIFIER($dwhm_db) TO ROLE ACCOUNTADMIN;
ALTER DATABASE IDENTIFIER($dwhm_db) SET DATA_RETENTION_TIME_IN_DAYS = 30;
REVOKE ROLE "DWHM_TRAVIS_TESTS" FROM ROLE ACCOUNTADMIN; 
```

Než se spustily testy:
`SHOW DATABASES LIKE 'DWHM_TRAVIS_TESTS';`
![image](https://user-images.githubusercontent.com/642928/54942581-b299ec80-4f2f-11e9-9d4b-50ab8cef806b.png)

Po tom, co se spustily testy:
`SHOW DATABASES LIKE 'DWHM_TRAVIS_TESTS';`
![image](https://user-images.githubusercontent.com/642928/54942637-cfcebb00-4f2f-11e9-9885-0d9a19da8bce.png)
